### PR TITLE
Add release badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Copy Files Action
+[![Release](https://github.com/JanCodeLab/action-copy-files/actions/workflows/release.yml/badge.svg)](https://github.com/JanCodeLab/action-copy-files/actions/workflows/release.yml)
 
 This GitHub Action copy files to target destination with folder structure creation and can be used across your organization.
 


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change adds a release badge to the top of the file to indicate the status of the release workflow.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R2): Added a release badge to show the status of the release workflow.